### PR TITLE
add resources : CMaterialColors

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -18,7 +18,7 @@
 | -------|------|
 |[Ucrop](https://github.com/Yalantis/uCrop) | 可以完成图片的裁剪，对用户的图片上传功能有帮助(已知 Bilibili 在用)
 |[Material Design](https://material.io/design) | 安卓应用的设计标准，内涵丰富的图标按钮资源
-|[CMaterialColors](https://github.com/FunnySaltyFish/CMaterialColors) | 包含所有MaterialDesignColor，在Jetpack Compose中轻松使用
+|[CMaterialColors](https://github.com/FunnySaltyFish/CMaterialColors) | 包含所有 MaterialDesignColor，在 Jetpack Compose 中轻松使用
 |[Intent](https://developer.android.com/training/sharing/send?hl=zh-cn#kotlin) | 安卓应用的分享功能
 |[Material Dialog](https://github.com/afollestad/material-dialogs) | 含有颜色、时间选择对话框等等
 |[Accompanist](https://github.com/google/accompanist) | Compose 一些开发中必备但是还无法使用的库，

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -18,6 +18,7 @@
 | -------|------|
 |[Ucrop](https://github.com/Yalantis/uCrop) | 可以完成图片的裁剪，对用户的图片上传功能有帮助(已知 Bilibili 在用)
 |[Material Design](https://material.io/design) | 安卓应用的设计标准，内涵丰富的图标按钮资源
+|[CMaterialColors](https://github.com/FunnySaltyFish/CMaterialColors) | 包含所有MaterialDesignColor，在Jetpack Compose中轻松使用
 |[Intent](https://developer.android.com/training/sharing/send?hl=zh-cn#kotlin) | 安卓应用的分享功能
 |[Material Dialog](https://github.com/afollestad/material-dialogs) | 含有颜色、时间选择对话框等等
 |[Accompanist](https://github.com/google/accompanist) | Compose 一些开发中必备但是还无法使用的库，


### PR DESCRIPTION
具体更改如下：
在 **Resources** 中新增一个开源库 [CMaterialColors](https://github.com/FunnySaltyFish/CMaterialColors)
[CMaterialColors](https://github.com/FunnySaltyFish/CMaterialColors) 是一个基础资源库，包含所有MaterialDesignColor，借助IDE的自动提示导入功能，可以做到想用什么  MaterialDesignColor ，直接写出来然后 `Alt+Enter`即可